### PR TITLE
Eliminate ISO C++ Variadic Macro Warnings

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -23,8 +23,8 @@
 
 #else
 
-#define DPRINTF(args...)
-#define DEBUG_PERROR(args...)
+#define DPRINTF(level, fmt, args...)
+#define DEBUG_PERROR(level, fmt, args...)
 
 #endif
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -16,15 +16,15 @@
  * a combination of DEBUG_ERRS, DEBUG_CUCKOO, DEBUG_TABLE, DEBUG_ENCODE
  */
 
-#define DPRINTF(level, fmt, args...) \
-    do { if (debug_level & (level)) fprintf(stdout, fmt , ##args ); } while(0)
+#define DPRINTF(level, ...) \
+    do { if (debug_level & (level)) fprintf(stdout, ##__VA_ARGS__ ); } while(0)
 #define DEBUG_PERROR(errmsg) \
     do { if (debug_level & DEBUG_ERRS) perror(errmsg); } while(0)
 
 #else
 
-#define DPRINTF(level, fmt, args...)
-#define DEBUG_PERROR(level, fmt, args...)
+#define DPRINTF(level, ...)
+#define DEBUG_PERROR(level, ...)
 
 #endif
 


### PR DESCRIPTION
GCC 5.1.0 outputs a number of variadic macro warnings when using cuckoofilter primarily due to ISO C++11 violations. Now, it's clear that your intended compiler is gcc given the use of __attribute__(packed) in your table, so a GCC extension isn't terrible, but I do prefer not having warnings during compilation, and some of these can't be silenced by compiler flags.

1. ISO C++ forbids named variadic macros. Substituting __VA_ARGS__ for args and ... for args... solves these compiler warnings.
2. At least one argument required for variadic macros. Since fmt always precedes args in your usage, it is trivial to omit listing it explicitly.

These changes eliminate all warnings.