### PR TITLE
A start at reproducing the benchmarks from the CoNEXT'14 paper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CC = g++
 #OPT = -O3 -DNDEBUG
 OPT = -g -ggdb
 
-CFLAGS += -Wall -c -I. -I./include -I/usr/include/ -I./src/ $(OPT)
+CFLAGS += -fno-strict-aliasing -Wall -c -I. -I./include -I/usr/include/ -I./src/ $(OPT)
 
 LDFLAGS+= -Wall -lpthread -lssl -lcrypto
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Repository structure
 --------------------
 *  ``src/``: the C++ implementation of cuckoo filter
 *  ``example/test.cc``: an example of using cuckoo filter
+*  ``benchmarks``: Some benchmarks of speed, space used, and false positive rate
 
 Usage
 -------
@@ -30,6 +31,9 @@ To build this example:
 
     $ make test
 
+To build the benchmarks:
+
+    $ (cd benchmarks/ && make)
 
 Authors
 -------

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,0 +1,18 @@
+# Uncomment one of the following to switch between debug and opt mode
+OPT = -O3 -DNDEBUG
+#OPT = -g -ggdb
+
+CXXFLAGS += -fno-strict-aliasing -Wall -std=c++11 -I. -I../src/ $(OPT)
+
+LDFLAGS+= -Wall -lpthread -lssl -lcrypto
+
+HEADERS = $(wildcard ../src/*.h) *.h
+
+SRC = ../src/hashutil.cc
+
+.PHONY: all
+
+all: conext-table3.exe conext-figure5.exe
+
+%.exe: %.cc ${HEADERS} ${SRC} Makefile
+	$(CXX) $(CXXFLAGS) $< -o $@ $(SRC) $(LDFLAGS)

--- a/benchmarks/conext-figure5.cc
+++ b/benchmarks/conext-figure5.cc
@@ -1,0 +1,84 @@
+// This benchmark reproduces the CoNEXT 2014 results found in "Figure 5: Lookup
+// performance when a filter achieves its capacity." It takes about two minutes to run on
+// an Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz.
+//
+// Results:
+// fraction of queries on existing items/lookup throughput (million OPS)
+//                      CF     ss-CF
+//         0.00%     24.79      9.37
+//        25.00%     24.65      9.57
+//        50.00%     24.84      9.57
+//        75.00%     24.86      9.62
+//       100.00%     24.89      9.96
+
+#include <climits>
+#include <iomanip>
+#include <vector>
+
+#include "cuckoofilter.h"
+#include "random.h"
+#include "timing.h"
+
+using namespace std;
+
+using namespace cuckoofilter;
+
+// The number of items sampled when determining the lookup performance
+const size_t SAMPLE_SIZE = 1000 * 1000;
+
+// The time (in seconds) to lookup SAMPLE_SIZE keys in which 0%, 25%, 50%, 75%, and 100%
+// of the keys looked up are found.
+template <typename Table>
+array<double, 5> CuckooBenchmark(
+    size_t add_count, const vector<uint64_t>& to_add, const vector<uint64_t>& to_lookup) {
+  Table cuckoo(add_count);
+  array<double, 5> result;
+
+  // Add values until failure or until we run out of values to add:
+  size_t added = 0;
+  while (added < to_add.size() && 0 == cuckoo.Add(to_add[added])) ++added;
+
+  // A value to track to prevent the compiler from optimizing out all lookups:
+  size_t found_count = 0;
+  for (const double found_percent : {0.0, 0.25, 0.50, 0.75, 1.00}) {
+    const auto to_lookup_mixed = MixIn(&to_lookup[0], &to_lookup[SAMPLE_SIZE], &to_add[0],
+        &to_add[added], found_percent);
+    auto start_time = NowNanos();
+    for (const auto v : to_lookup_mixed) found_count += (0 == cuckoo.Contain(v));
+    auto lookup_time = NowNanos() - start_time;
+    result[found_percent * 4] = lookup_time / (1000.0 * 1000.0 * 1000.0);
+  }
+  if (6 * SAMPLE_SIZE == found_count) exit(1);
+  return result;
+}
+
+int main() {
+  // Number of distinct values, used only for the constructor of CuckooFilter, which does
+  // not allow the caller to specify the space usage directly. The actual number of
+  // distinct items inserted depends on how many fit until an insert failure occurs.
+  size_t add_count = 127.78 * 1000 * 1000;
+
+  // Overestimate add_count so we don't run out of random data:
+  const size_t max_add_count = 2 * add_count;
+  const vector<uint64_t> to_add = GenerateRandom64(max_add_count);
+  const vector<uint64_t> to_lookup = GenerateRandom64(SAMPLE_SIZE);
+
+  // Calculate metrics:
+  const auto cf = CuckooBenchmark<
+      CuckooFilter<uint64_t, 12 /* bits per item */, SingleTable /* not semi-sorted*/>>(
+      add_count, to_add, to_lookup);
+  const auto sscf = CuckooBenchmark<
+      CuckooFilter<uint64_t, 13 /* bits per item */, PackedTable /* semi-sorted*/>>(
+      add_count, to_add, to_lookup);
+
+  cout << "fraction of queries on existing items/lookup throughput (million OPS) "
+       << endl;
+  cout << setw(10) << ""
+       << " " << setw(10) << right << "CF" << setw(10) << right << "ss-CF" << endl;
+  for (const double found_percent : {0.0, 0.25, 0.50, 0.75, 1.00}) {
+    cout << fixed << setprecision(2) << setw(10) << right << 100 * found_percent << "%";
+    cout << setw(10) << right << (SAMPLE_SIZE / cf[found_percent * 4]) / (1000 * 1000);
+    cout << setw(10) << right << (SAMPLE_SIZE / sscf[found_percent * 4]) / (1000 * 1000);
+    cout << endl;
+  }
+}

--- a/benchmarks/conext-table3.cc
+++ b/benchmarks/conext-table3.cc
@@ -1,0 +1,91 @@
+// This benchmark reproduces the CoNEXT 2014 results found in "Table 3: Space efficiency
+// and construction speed." It takes about two minutes to run on an Intel(R) Core(TM)
+// i7-4790 CPU @ 3.60GHz.
+//
+// Results:
+//
+// metrics                                    CF     ss-CF
+// # of items (million)                   127.82    127.90
+// bits per item                           12.60     12.59
+// false positive rate                     0.18%     0.09%
+// constr. speed (million keys/sec)         5.86      4.10
+
+#include <climits>
+#include <iomanip>
+#include <vector>
+
+#include "cuckoofilter.h"
+#include "random.h"
+#include "timing.h"
+
+using namespace std;
+
+using namespace cuckoofilter;
+
+// The number of items sampled when determining the false positive rate
+const size_t FPR_SAMPLE_SIZE = 1000 * 1000;
+
+struct Metrics {
+  double add_count;  // # of items (million)
+  double space;      // bits per item
+  double fpr;        // false positive rate (%)
+  double speed;      // const. speed (million keys/sec)
+};
+
+template<typename Table>
+Metrics CuckooBenchmark(size_t add_count, const vector<uint64_t>& input) {
+  Table cuckoo(add_count);
+  auto start_time = NowNanos();
+
+  // Insert until failure:
+  size_t inserted = 0;
+  while (inserted < input.size() && 0 == cuckoo.Add(input[inserted])) ++inserted;
+
+  auto constr_time = NowNanos() - start_time;
+
+  // Count false positives:
+  size_t false_positive_count = 0;
+  size_t absent = 0;
+  for (; inserted + absent < input.size() && absent < FPR_SAMPLE_SIZE; ++absent) {
+    false_positive_count += (0 == cuckoo.Contain(input[inserted + absent]));
+  }
+
+  // Calculate metrics:
+  const auto time = constr_time / static_cast<double>(1000 * 1000 * 1000);
+  Metrics result;
+  result.add_count = static_cast<double>(inserted) / (1000 * 1000);
+  result.space = static_cast<double>(CHAR_BIT * cuckoo.SizeInBytes()) / inserted;
+  result.fpr = (100.0 * false_positive_count) / absent;
+  result.speed = (inserted / time) / (1000 * 1000);
+  return result;
+}
+
+int main() {
+  // Number of distinct values, used only for the constructor of CuckooFilter, which does
+  // not allow the caller to specify the space usage directly. The actual number of
+  // distinct items inserted depends on how many fit until an insert failure occurs.
+  const size_t add_count = 127.78 * 1000 * 1000;
+
+  // Overestimate add_count so we don't run out of random data:
+  const size_t max_add_count = 2 * add_count;
+  const vector<uint64_t> input = GenerateRandom64(max_add_count + FPR_SAMPLE_SIZE);
+
+  // Calculate metrics:
+  const auto cf = CuckooBenchmark<
+      CuckooFilter<uint64_t, 12 /* bits per item */, SingleTable /* not semi-sorted*/>>(
+      add_count, input);
+  const auto sscf = CuckooBenchmark<
+      CuckooFilter<uint64_t, 13 /* bits per item */, PackedTable /* semi-sorted*/>>(
+      add_count, input);
+
+  cout << setw(35) << left << "metrics " << setw(10) << right << "CF" << setw(10)
+       << "ss-CF" << endl
+       << fixed << setprecision(2) << setw(35) << left << "# of items (million) "
+       << setw(10) << right << cf.add_count << setw(10) << sscf.add_count << endl
+       << setw(35) << left << "bits per item " << setw(10) << right << cf.space
+       << setw(10) << sscf.space << endl
+       << setw(35) << left << "false positive rate " << setw(9) << right << cf.fpr << "%"
+       << setw(9) << sscf.fpr << "%" << endl
+       << setw(35) << left << "constr. speed (million keys/sec) " << setw(10) << right
+       << cf.speed << setw(10) << sscf.speed << endl;
+}

--- a/benchmarks/random.h
+++ b/benchmarks/random.h
@@ -1,0 +1,45 @@
+// Generating random data
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <random>
+#include <stdexcept>
+#include <vector>
+
+
+::std::vector<::std::uint64_t> GenerateRandom64(::std::size_t count) {
+  ::std::vector<::std::uint64_t> result(count);
+  ::std::random_device random;
+  // To generate random keys to lookup, this uses ::std::random_device which is slower but
+  // stronger than some other pseudo-random alternatives. The reason is that some of these
+  // alternatives (like libstdc++'s ::std::default_random, which is a linear congruential
+  // generator) behave non-randomly under some hash families like Dietzfelbinger's
+  // multiply-shift.
+  auto genrand = [&random]() {
+    return random() + (static_cast<::std::uint64_t>(random()) << 32);
+  };
+  ::std::generate(result.begin(), result.end(), ::std::ref(genrand));
+  return result;
+}
+
+// Using two pointer ranges for sequences x and y, create a vector clone of x but for
+// y_probability y's mixed in.
+template <typename T>
+::std::vector<T> MixIn(const T* x_begin, const T* x_end, const T* y_begin, const T* y_end,
+    double y_probability) {
+  const auto x_size = x_end - x_begin, y_size = y_end - y_begin;
+  if (y_size > (1ull << 32)) throw ::std::length_error("y is too long");
+  ::std::vector<T> result(x_begin, x_end);
+  ::std::random_device random;
+  auto genrand = [&random, y_size]() {
+    return (static_cast<size_t>(random()) * y_size) >> 32;
+  };
+  for (size_t i = 0; i < y_probability * x_size; ++i) {
+    result[i] = *(y_begin + genrand());
+  }
+  ::std::shuffle(result.begin(), result.end(), random);
+  return result;
+}

--- a/benchmarks/timing.h
+++ b/benchmarks/timing.h
@@ -1,0 +1,12 @@
+// Timers for use in benchmarking.
+
+#pragma once
+
+#include <cstdint>
+#include <chrono>
+
+::std::uint64_t NowNanos() {
+  return ::std::chrono::duration_cast<::std::chrono::nanoseconds>(
+             ::std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}

--- a/src/debug.h
+++ b/src/debug.h
@@ -23,8 +23,8 @@
 
 #else
 
-#define DPRINTF(args...)
-#define DEBUG_PERROR(args...)
+#define DPRINTF(level, fmt, args...)
+#define DEBUG_PERROR(level, fmt, args...)
 
 #endif
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -16,15 +16,15 @@
  * a combination of DEBUG_ERRS, DEBUG_CUCKOO, DEBUG_TABLE, DEBUG_ENCODE
  */
 
-#define DPRINTF(level, fmt, args...) \
-    do { if (debug_level & (level)) fprintf(stdout, fmt , ##args ); } while(0)
+#define DPRINTF(level, ...) \
+    do { if (debug_level & (level)) fprintf(stdout, ##__VA_ARGS__ ); } while(0)
 #define DEBUG_PERROR(errmsg) \
     do { if (debug_level & DEBUG_ERRS) perror(errmsg); } while(0)
 
 #else
 
-#define DPRINTF(level, fmt, args...)
-#define DEBUG_PERROR(level, fmt, args...)
+#define DPRINTF(level, ...)
+#define DEBUG_PERROR(level, ...)
 
 #endif
 

--- a/src/hashutil.h
+++ b/src/hashutil.h
@@ -39,6 +39,18 @@ namespace cuckoofilter {
         static std::string MD5Hash(const char* inbuf, size_t in_length);
         static std::string SHA1Hash(const char* inbuf, size_t in_length);
 
+        // See Martin Dietzfelbinger, "Universal hashing and k-wise independent random
+        // variables via integer arithmetic without primes".
+        static uint64_t TwoIndependentMultiplyShift(uint64_t key) {
+          constexpr uint64_t SEED[4] = {
+              0x818c3f78ull, 0x672f4a3aull, 0xabd04d69ull, 0x12b51f95ull};
+          const unsigned __int128 m =
+              *reinterpret_cast<const unsigned __int128 *>(&SEED[0]);
+          const unsigned __int128 a =
+              *reinterpret_cast<const unsigned __int128 *>(&SEED[2]);
+          return (a + m * key) >> 64;
+        }
+
     private:
         HashUtil();
     };


### PR DESCRIPTION
The benchmarking code from "Cuckoo Filter: Practically Better Than Bloom", by Fan et al. was apparently lost years ago.

This PR reproduces some of the benchmarks. At this point it includes only benchmarks for the cuckoo filters, not ones for traditional Bloom filters, blocked Bloom filters, Quotient filters, and d-left counting Bloom filters, which were in the paper. The particular implementations of those other filters tested in the CoNEXT'14 paper are not in this repo.