### PR TITLE
Parameterize cuckoo filter on hash family.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CC = g++
 #OPT = -O3 -DNDEBUG
 OPT = -g -ggdb
 
-CFLAGS += -fno-strict-aliasing -Wall -c -I. -I./include -I/usr/include/ -I./src/ $(OPT)
+CFLAGS += --std=c++11 -fno-strict-aliasing -Wall -c -I. -I./include -I/usr/include/ -I./src/ $(OPT)
 
 LDFLAGS+= -Wall -lpthread -lssl -lcrypto
 

--- a/benchmarks/bulk-insert-and-query.cc
+++ b/benchmarks/bulk-insert-and-query.cc
@@ -137,8 +137,8 @@ struct FilterAPI<CuckooFilter<ItemType, bits_per_item, TableType>> {
 };
 
 template <>
-struct FilterAPI<SimdBlockFilter> {
-  using Table = SimdBlockFilter;
+struct FilterAPI<SimdBlockFilter<>> {
+  using Table = SimdBlockFilter<>;
   static Table ConstructFromAddCount(size_t add_count) {
     Table ans(ceil(log2(add_count * 8.0 / CHAR_BIT)));
     return ans;
@@ -248,7 +248,7 @@ int main(int argc, char * argv[]) {
 
   cout << setw(NAME_WIDTH) << "SemiSort17" << cf << endl;
 
-  cf = FilterBenchmark<SimdBlockFilter>(add_count, to_add, to_lookup);
+  cf = FilterBenchmark<SimdBlockFilter<>>(add_count, to_add, to_lookup);
 
   cout << setw(NAME_WIDTH) << "SimdBlock8" << cf << endl;
 

--- a/benchmarks/random.h
+++ b/benchmarks/random.h
@@ -30,7 +30,7 @@
 template <typename T>
 ::std::vector<T> MixIn(const T* x_begin, const T* x_end, const T* y_begin, const T* y_end,
     double y_probability) {
-  const auto x_size = x_end - x_begin, y_size = y_end - y_begin;
+  const size_t x_size = x_end - x_begin, y_size = y_end - y_begin;
   if (y_size > (1ull << 32)) throw ::std::length_error("y is too long");
   ::std::vector<T> result(x_begin, x_end);
   ::std::random_device random;

--- a/src/hashutil.h
+++ b/src/hashutil.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include <openssl/evp.h>
+#include <random>
 
 namespace cuckoofilter {
 
@@ -19,8 +20,7 @@ class HashUtil {
 
   // Bob Jenkins Hash that returns two indices in one call
   // Useful for Cuckoo hashing, power of two choices, etc.
-  // Use idx1 before idx2, when possible. idx1 and idx2 should be initialized to
-  // seeds.
+  // Use idx1 before idx2, when possible. idx1 and idx2 should be initialized to seeds.
   static void BobHash(const void *buf, size_t length, uint32_t *idx1,
                       uint32_t *idx2);
   static void BobHash(const std::string &s, uint32_t *idx1, uint32_t *idx2);
@@ -40,22 +40,54 @@ class HashUtil {
   static std::string MD5Hash(const char *inbuf, size_t in_length);
   static std::string SHA1Hash(const char *inbuf, size_t in_length);
 
-  // See Martin Dietzfelbinger, "Universal hashing and k-wise independent random
-  // variables via integer arithmetic without primes".
-  static uint64_t TwoIndependentMultiplyShift(uint64_t key) {
-    const uint64_t SEED[4] = {0x818c3f78ull, 0x672f4a3aull, 0xabd04d69ull,
-                              0x12b51f95ull};
-    const unsigned __int128 m =
-        *reinterpret_cast<const unsigned __int128 *>(&SEED[0]);
-    const unsigned __int128 a =
-        *reinterpret_cast<const unsigned __int128 *>(&SEED[2]);
-    return (a + m * key) >> 64;
-  }
-
  private:
   HashUtil();
 };
 
-}  // namespace cuckoofilter
+// See Martin Dietzfelbinger, "Universal hashing and k-wise independent random
+// variables via integer arithmetic without primes".
+class TwoIndependentMultiplyShift {
+  unsigned __int128 multiply_, add_;
+
+ public:
+  TwoIndependentMultiplyShift() {
+    ::std::random_device random;
+    for (auto v : {&multiply_, &add_}) {
+      *v = random();
+      for (int i = 1; i <= 4; ++i) {
+        *v = *v << 32;
+        *v |= random();
+      }
+    }
+  }
+
+  uint64_t operator()(uint64_t key) const {
+    return (add_ + multiply_ * static_cast<decltype(multiply_)>(key)) >> 64;
+  }
+};
+
+// See Patrascu and Thorup's "The Power of Simple Tabulation Hashing"
+class SimpleTabulation {
+  uint64_t tables_[sizeof(uint64_t)][1 << CHAR_BIT];
+
+ public:
+  SimpleTabulation() {
+    ::std::random_device random;
+    for (unsigned i = 0; i < sizeof(uint64_t); ++i) {
+      for (int j = 0; j < (1 << CHAR_BIT); ++j) {
+        tables_[i][j] = random() | ((static_cast<uint64_t>(random())) << 32);
+      }
+    }
+  }
+
+  uint64_t operator()(uint64_t key) const {
+    uint64_t result = 0;
+    for (unsigned i = 0; i < sizeof(key); ++i) {
+      result ^= tables_[i][reinterpret_cast<uint8_t *>(&key)[i]];
+    }
+    return result;
+  }
+};
+}
 
 #endif  // CUCKOO_FILTER_HASHUTIL_H_


### PR DESCRIPTION
Add two hash families: two-independent multiply-shift and simple
tabulation. The interface for the hash family is like that used in
std::unordered_*.