### PR TITLE
Makefile: Add install and uninstall targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 CC = g++
+AR = ar
+PREFIX=/usr/local
 
 # Uncomment one of the following to switch between debug and opt mode
 #OPT = -O3 -DNDEBUG
@@ -12,6 +14,7 @@ LIBOBJECTS = \
 	./src/hashutil.o \
 
 HEADERS = $(wildcard src/*.h)
+ALIB = libcuckoofilter.a
 
 TEST = test
 
@@ -26,3 +29,15 @@ test: example/test.o $(LIBOBJECTS)
 %.o: %.cc ${HEADERS} Makefile
 	$(CC) $(CFLAGS) $< -o $@
 
+$(ALIB): $(LIBOBJECTS)
+	$(AR) rcs $@ $(LIBOBJECTS)
+
+.PHONY: install
+install: $(ALIB)
+	install -D -m 0755 $(HEADERS) -t $(DESTDIR)$(PREFIX)/include/cuckoofilter
+	install -D -m 0755 $< -t $(DESTDIR)$(PREFIX)/lib
+
+.PHONY: uninstall
+uninstall:
+	rm -f $(DESTDIR)$(PREFIX)/lib/$(ALIB)
+	rm -rf $(DESTDIR)$(PREFIX)/include/cuckoofilter

--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ $ cd benchmarks
 $ make
 ```
 
+Install
+-------
+To install the cuckoofilter library:
+```bash
+$ make install
+```
+By default, the header files will be placed in `/usr/local/include/cuckoofilter`
+and the static library at `/usr/local/lib/cuckoofilter.a`.
+
 
 Contributing
 ------------


### PR DESCRIPTION
for header files + static library.

I created this so that I can use cuckoofilter library without incorporating the repository in the project using it. What do you think?

I chose to build a static library because I couldn't really get a dynamic one to work, because building a dynamic one is much more complex to do in plain Makefiles.