### PR TITLE
Add padding buckets to avoid buffer overrun on SingleTable

### DIFF
--- a/src/singletable.h
+++ b/src/singletable.h
@@ -20,6 +20,10 @@ class SingleTable {
   static const size_t kBytesPerBucket =
       (bits_per_tag * kTagsPerBucket + 7) >> 3;
   static const uint32_t kTagMask = (1ULL << bits_per_tag) - 1;
+  // NOTE: accomodate extra buckets if necessary to avoid overrun
+  // as we always read a uint64
+  static const size_t kPaddingBuckets =
+    ((((kBytesPerBucket + 7) / 8) * 8) - 1) / kBytesPerBucket;
 
   struct Bucket {
     char bits_[kBytesPerBucket];
@@ -31,8 +35,8 @@ class SingleTable {
 
  public:
   explicit SingleTable(const size_t num) : num_buckets_(num) {
-    buckets_ = new Bucket[num_buckets_];
-    memset(buckets_, 0, kBytesPerBucket * num_buckets_);
+    buckets_ = new Bucket[num_buckets_ + kPaddingBuckets];
+    memset(buckets_, 0, kBytesPerBucket * (num_buckets_ + kPaddingBuckets));
   }
 
   ~SingleTable() { 


### PR DESCRIPTION
This PR fixes the issue reported on #3.
This is can be reproduced using the `test.cc` file without change. Because the buffer read is unaligned (and we read 64-bit values) we need to make sure there is some extra space at the end to account for that.

Here I calculate how many "extra" buckets we need in a generic way. This is done similarly to what is present on `packedtable.h`