### PR TITLE
Restrict table bits_per_tag at compile time

### DIFF
--- a/src/packedtable.h
+++ b/src/packedtable.h
@@ -13,6 +13,10 @@ namespace cuckoofilter {
 // Using Permutation encoding to save 1 bit per tag
 template <size_t bits_per_tag>
 class PackedTable {
+  static_assert(bits_per_tag == 5 || bits_per_tag == 6 || bits_per_tag == 7 ||
+                    bits_per_tag == 8 || bits_per_tag == 9 ||
+                    bits_per_tag == 13 || bits_per_tag == 17,
+                "bits_per_tag must be 5, 6, 7, 8, 9, 13, or 17");
   static const size_t kDirBitsPerTag = bits_per_tag - 4;
   static const size_t kBitsPerBucket = (3 + kDirBitsPerTag) * 4;
   static const size_t kBytesPerBucket = (kBitsPerBucket + 7) >> 3;

--- a/src/singletable.h
+++ b/src/singletable.h
@@ -14,6 +14,10 @@ namespace cuckoofilter {
 // the most naive table implementation: one huge bit array
 template <size_t bits_per_tag>
 class SingleTable {
+  static_assert(bits_per_tag == 2 || bits_per_tag == 4 || bits_per_tag == 8 ||
+                    bits_per_tag == 12 || bits_per_tag == 16 ||
+                    bits_per_tag == 32,
+                "bits_per_tag must be 2, 4, 8, 12, 16, or 32");
   static const size_t kTagsPerBucket = 4;
   static const size_t kBytesPerBucket =
       (bits_per_tag * kTagsPerBucket + 7) >> 3;


### PR DESCRIPTION
Previously this would fail silently at run time.

This closes #34.