### PR TITLE
Remove machine-dependent include flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PREFIX=/usr/local
 #OPT = -O3 -DNDEBUG
 OPT = -g -ggdb
 
-CFLAGS += --std=c++11 -fno-strict-aliasing -Wall -c -I. -I./include -I/usr/include/ -I./src/ $(OPT)
+CFLAGS += --std=c++11 -fno-strict-aliasing -Wall -c -I. -I./include -I./src/ $(OPT)
 
 LDFLAGS+= -Wall -lpthread -lssl -lcrypto
 


### PR DESCRIPTION
`/usr/include` is included by default on systems that have it. Doing so explicitly may actually make it fail on systems that store shared headers in a different directory, such as NixOS.